### PR TITLE
New require API.

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
-var connect = __meteor_bootstrap__.require("connect");
-var fs = __meteor_bootstrap__.require("fs");
-var path = __meteor_bootstrap__.require("path");
+var connect = Npm.require("connect");
+var fs = Npm.require("fs");
+var path = Npm.require("path");
+var Fiber = Npm.require("fibers");
 
 __meteor_bootstrap__.app
     .use(connect.query())


### PR DESCRIPTION
Meteor 0.6.0 introduced the new Npm.require API, the old method doesn't work anymore.
