### PR TITLE
.save() throws as error cuz we're saving something to MongoDB with a $.

### DIFF
--- a/client.js
+++ b/client.js
@@ -17,6 +17,9 @@ function() {
 	function ObjectFactory(collection, objectvalue) {
 		if(!objectvalue){return;}
 		objectvalue.save = function() {
+			objectvalue = angular.copy(objectvalue);
+			cleanupAngularObject(objectvalue);
+
 			collection.update({
 				_id : this._id
 			}, objectvalue);


### PR DESCRIPTION
I was getting some errors trying to use the `.save()` shortcut and found that it was because I was trying to save something to MongoDB (a field) that started with a `$`, which is illegal.

I saw the `cleanupAngularObject` method, and that it was being used... but not `.save()`.
